### PR TITLE
compatibility with `laspy >= 2.1.1`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+Unreleased
+----------
+
+* fix: compatibility with lastest laspy version (>= 2.1.1, (2.1.0 have a bug))
+
+
 0.4.3 (2020-09-24)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 Unreleased
 ----------
 
-* fix: compatibility with lastest laspy version (>= 2.1.1, (2.1.0 have a bug))
+* fix: compatibility with latest laspy version (>= 2.1.1, (2.1.0 has a bug))
 
 
 0.4.3 (2020-09-24)

--- a/jakteristics/constants.py
+++ b/jakteristics/constants.py
@@ -1,4 +1,3 @@
-
 FEATURE_NAMES = [
     "eigenvalue_sum",
     "omnivariance",

--- a/jakteristics/las_utils.py
+++ b/jakteristics/las_utils.py
@@ -10,7 +10,7 @@ def read_las_xyz(
     filename: Union[str, Path], with_offset: bool = False
 ) -> Union[np.array, Tuple[np.ndarray, List[float]]]:
     """Reads xyz coordinates of a las file, optionally as single precision floating point.
-    
+
     Arguments:
         filename:
             The las file to read
@@ -34,10 +34,13 @@ def read_las_xyz(
 
 
 def write_with_extra_dims(
-    input_path: Path, output_path: Path, extra_dims: np.array, extra_dims_names: List,
+    input_path: Path,
+    output_path: Path,
+    extra_dims: np.array,
+    extra_dims_names: List,
 ):
     """From an existing las file, create a new las file with extra dimensions
-    
+
     Arguments:
         input_path: The input las file.
         output_path: The output las file.
@@ -56,7 +59,10 @@ def write_with_extra_dims(
             )
 
         data = [(name, extra_dims[:, i]) for i, name in enumerate(extra_dims_names)]
-        new_dimensions = [laspy.ExtraBytesParams(name=name, type=extra_dims.dtype, description=name) for name in extra_dims_names]
+        new_dimensions = [
+            laspy.ExtraBytesParams(name=name, type=extra_dims.dtype, description=name)
+            for name in extra_dims_names
+        ]
 
         # insert new data in previous pointcloud PackedPointRecord
         las_data = in_las.read()

--- a/jakteristics/las_utils.py
+++ b/jakteristics/las_utils.py
@@ -56,7 +56,7 @@ def write_with_extra_dims(
             )
 
         data = [(name, extra_dims[:, i]) for i, name in enumerate(extra_dims_names)]
-        new_dimensions = [laspy.ExtraBytesParams(**{"name": name, "type": array.dtype, "description": name}) for (name, array,) in data]
+        new_dimensions = [laspy.ExtraBytesParams(name=name, type=extra_dims.dtype, description=name) for name in extra_dims_names]
 
         # insert new data in previous pointcloud PackedPointRecord
         las_data = in_las.read()

--- a/jakteristics/las_utils.py
+++ b/jakteristics/las_utils.py
@@ -67,23 +67,3 @@ def write_with_extra_dims(
 
         with laspy.open(output_path, mode="w", header=las_data.header) as out_las:
             out_las.write_points(las_data.points)
-
-
-def _get_las_data_type(array):
-    las_data_types = [
-        "int8",
-        "uint8",
-        "int16",
-        "uint16",
-        "int32",
-        "uint32",
-        "int64",
-        "uint64",
-        "float32",
-        "float64",
-        # "S",  # strings not implemented
-    ]
-    type_ = str(array.dtype)
-    if type_ not in las_data_types:  # pragma: no cover
-        raise NotImplementedError(f"Array type not implemented: {type_}")
-    return las_data_types.index(type_) + 1

--- a/jakteristics/las_utils.py
+++ b/jakteristics/las_utils.py
@@ -22,18 +22,14 @@ def read_las_xyz(
         Depending on the `with_offset` parameter, either an (n x 3) array, or
         a tuple of an (n x 3) array and the file offset.
     """
-    with laspy.file.File(filename, mode="r") as las:
+    with laspy.open(filename, mode="r") as las:
+        las_data = las.read()
         if with_offset:
             offset = las.header.offset
-            out = np.empty((las.header.count, 3), dtype="f")
-            points = np.stack(
-                [las.x - offset[0], las.y - offset[1], las.z - offset[2]],
-                axis=1,
-                out=out,
-            )
+            points = np.ascontiguousarray(las_data.xyz - offset, dtype="f")
             return points, offset
         else:
-            points = np.stack([las.x, las.y, las.z], axis=1)
+            points = np.ascontiguousarray(las_data.xyz)
             return points
 
 
@@ -51,27 +47,26 @@ def write_with_extra_dims(
     if input_path == output_path:
         raise ValueError("Paths must not be the same")
 
-    with laspy.file.File(input_path, mode="r") as in_las:
+    with laspy.open(input_path, mode="r") as in_las:
         header = in_las.header
-        if extra_dims.shape[0] != header.count:
+        if extra_dims.shape[0] != header.point_count:
             raise ValueError(
                 f"The features and point counts should be equal "
-                f"{extra_dims.shape[0]} != {header.count}"
+                f"{extra_dims.shape[0]} != {header.point_count}"
             )
 
-        with laspy.file.File(output_path, mode="w", header=in_las.header) as out_las:
-            data = [(name, extra_dims[:, i]) for i, name in enumerate(extra_dims_names)]
+        data = [(name, extra_dims[:, i]) for i, name in enumerate(extra_dims_names)]
+        new_dimensions = [laspy.ExtraBytesParams(**{"name": name, "type": array.dtype, "description": name}) for (name, array,) in data]
 
-            for name, array in data:
-                data_type = _get_las_data_type(array)
-                out_las.define_new_dimension(name, data_type, name)
+        # insert new data in previous pointcloud PackedPointRecord
+        las_data = in_las.read()
+        las_data.add_extra_dims(new_dimensions)
+        las_data.update_header()
+        for name, array in data:
+            setattr(las_data, name, array)
 
-            for spec in in_las.reader.point_format:
-                in_spec = in_las.reader.get_dimension(spec.name)
-                out_las.writer.set_dimension(spec.name, in_spec)
-
-            for name, array in data:
-                setattr(out_las, name, array)
+        with laspy.open(output_path, mode="w", header=las_data.header) as out_las:
+            out_las.write_points(las_data.points)
 
 
 def _get_las_data_type(array):

--- a/jakteristics/main.py
+++ b/jakteristics/main.py
@@ -54,7 +54,7 @@ def compute_features(
             distance to the real k-th nearest neighbor.
 
     Returns:
-        The computed features, one row per query point, and one column 
+        The computed features, one row per query point, and one column
         per requested feature.
     """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-laspy>=1.7
+laspy>=2.1.1
 scipy
 typer
 Cython>=0.25

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -105,11 +105,12 @@ def test_write_extra_dims(tmp_path):
     las_utils.write_with_extra_dims(input_path, output_path, features, FEATURE_NAMES)
 
     output_features = []
-    with laspy.file.File(output_path, mode="r") as las:
-        xyz_out = np.stack([las.x, las.y, las.z], axis=1)
-        for spec in las.reader.extra_dimensions:
-            name = spec.name.replace(b"\x00", b"").decode()
-            output_features.append(getattr(las, name))
+    with laspy.open(output_path, mode="r") as las:
+        las_data = las.read()
+        xyz_out = las_data.xyz
+        for spec in las.header.point_format.extra_dimensions:
+            name = spec.name.encode().replace(b"\x00", b"").decode()
+            output_features.append(getattr(las_data, name))
 
         output_features = np.vstack(output_features).T
 

--- a/tests/test_las_utils.py
+++ b/tests/test_las_utils.py
@@ -21,7 +21,7 @@ def test_read_las_offset():
     xyz, offset = las_utils.read_las_xyz(input_file, with_offset=True)
     assert xyz.shape == (10310, 3)
     assert xyz.dtype == np.float32
-    assert offset == [362327.0, 5157620.0, 106.271]
+    assert np.allclose(offset, np.array([362327.0, 5157620.0, 106.271]))
 
 
 def test_write_extra_dims_same_path():


### PR DESCRIPTION
- `jakteristics ` was written with an old API of laspy (< 2.0 two years ago).
- This PR updates read/write functions to support recent API of laspy.
